### PR TITLE
MAINT: 2017.8 version bump (pt 1 of N)

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -71,6 +71,16 @@ MAP = {
     'distro/core/qiime20177-1501699215.zip':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/distro/core/qiime20177-1501699215.zip',
 
+    # 2017.8 DISTRO
+    'distro/core/qiime2-2017.8-conda-osx-64.txt':
+        'https://raw.githubusercontent.com/qiime2/environment-files/master/2017.8/release/qiime2-2017.8-conda-osx-64.txt',
+    'distro/core/qiime2-2017.8-conda-linux-64.txt':
+        'https://raw.githubusercontent.com/qiime2/environment-files/master/2017.8/release/qiime2-2017.8-conda-linux-64.txt',
+    'distro/core/2017.8':
+        'http://google.com',
+    'distro/core/qiime20178-BUILD.zip':
+        'http://google.com',
+
     # 2.0.5
     '2.0.5/common/gg-13-8-99-515-806-nb-classifier.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2.0.5/common/gg-13-8-99-515-806-nb-classifier.qza',
@@ -562,4 +572,100 @@ MAP = {
         'https://docs.google.com/spreadsheets/d/1LnHBswZk6MFJWelQ6-A2TL7TH3tyG0NX7omM2pFyfyQ/export?gid=0&format=tsv',
     '2017.7/tutorials/moving-pictures/sample_metadata':
         'https://docs.google.com/spreadsheets/d/1LnHBswZk6MFJWelQ6-A2TL7TH3tyG0NX7omM2pFyfyQ/edit?usp=sharing',
+
+    # 2017.8
+    '2017.8/common/gg-13-8-99-515-806-nb-classifier.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/common/gg-13-8-99-515-806-nb-classifier.qza',
+    '2017.8/common/gg-13-8-99-nb-classifier.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/common/gg-13-8-99-nb-classifier.qza',
+    '2017.8/common/silva-119-99-515-806-nb-classifier.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/common/silva-119-99-515-806-nb-classifier.qza',
+    '2017.8/common/silva-119-99-nb-classifier.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/common/silva-119-99-nb-classifier.qza',
+    '2017.8/tutorials/atacama-soils/10p/barcodes.fastq.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/atacama-soils/10p/barcodes.fastq.gz',
+    '2017.8/tutorials/atacama-soils/10p/forward.fastq.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/atacama-soils/10p/forward.fastq.gz',
+    '2017.8/tutorials/atacama-soils/10p/reverse.fastq.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/atacama-soils/10p/reverse.fastq.gz',
+    '2017.8/tutorials/atacama-soils/1p/barcodes.fastq.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/atacama-soils/1p/barcodes.fastq.gz',
+    '2017.8/tutorials/atacama-soils/1p/forward.fastq.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/atacama-soils/1p/forward.fastq.gz',
+    '2017.8/tutorials/atacama-soils/1p/reverse.fastq.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/atacama-soils/1p/reverse.fastq.gz',
+    '2017.8/tutorials/exporting/feature-table.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/exporting/feature-table.qza',
+    '2017.8/tutorials/exporting/unrooted-tree.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/exporting/unrooted-tree.qza',
+    '2017.8/tutorials/filtering/distance-matrix.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/filtering/distance-matrix.qza',
+    '2017.8/tutorials/filtering/table.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/filtering/table.qza',
+    '2017.8/tutorials/fmt/fmt-tutorial-demux-1-10p.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/fmt/fmt-tutorial-demux-1-10p.qza',
+    '2017.8/tutorials/fmt/fmt-tutorial-demux-1-1p.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/fmt/fmt-tutorial-demux-1-1p.qza',
+    '2017.8/tutorials/fmt/fmt-tutorial-demux-2-10p.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/fmt/fmt-tutorial-demux-2-10p.qza',
+    '2017.8/tutorials/fmt/fmt-tutorial-demux-2-1p.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/fmt/fmt-tutorial-demux-2-1p.qza',
+    '2017.8/tutorials/gneiss/map.txt':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/gneiss/map.txt',
+    '2017.8/tutorials/gneiss/table.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/gneiss/table.qza',
+    '2017.8/tutorials/gneiss/taxa.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/gneiss/taxa.qza',
+    '2017.8/tutorials/importing/aligned-sequences.fna':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/aligned-sequences.fna',
+    '2017.8/tutorials/importing/casava-18-paired-end-demultiplexed.zip':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/casava-18-paired-end-demultiplexed.zip',
+    '2017.8/tutorials/importing/casava-18-single-end-demultiplexed.zip':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/casava-18-single-end-demultiplexed.zip',
+    '2017.8/tutorials/importing/feature-table-v100.biom':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/feature-table-v100.biom',
+    '2017.8/tutorials/importing/feature-table-v210.biom':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/feature-table-v210.biom',
+    '2017.8/tutorials/importing/pe-64-manifest':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/pe-64-manifest',
+    '2017.8/tutorials/importing/pe-64.zip':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/pe-64.zip',
+    '2017.8/tutorials/importing/se-33-manifest':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/se-33-manifest',
+    '2017.8/tutorials/importing/se-33.zip':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/se-33.zip',
+    '2017.8/tutorials/importing/sequences.fna':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/sequences.fna',
+    '2017.8/tutorials/importing/unrooted-tree.tre':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/importing/unrooted-tree.tre',
+    '2017.8/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz',
+    '2017.8/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz',
+    '2017.8/tutorials/metadata/faith_pd_vector.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/metadata/faith_pd_vector.qza',
+    '2017.8/tutorials/metadata/rep-seqs.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/metadata/rep-seqs.qza',
+    '2017.8/tutorials/metadata/taxonomy.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/metadata/taxonomy.qza',
+    '2017.8/tutorials/metadata/unweighted_unifrac_pcoa_results.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/metadata/unweighted_unifrac_pcoa_results.qza',
+    '2017.8/tutorials/training-feature-classifiers/85_otu_taxonomy.txt':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/training-feature-classifiers/85_otu_taxonomy.txt',
+    '2017.8/tutorials/training-feature-classifiers/85_otus.fasta':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/training-feature-classifiers/85_otus.fasta',
+    '2017.8/tutorials/training-feature-classifiers/rep-seqs.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/training-feature-classifiers/rep-seqs.qza',
+    '2017.8/tutorials/atacama-soils/sample_metadata.tsv':
+        'https://docs.google.com/spreadsheets/d/1xfDp25wDgnGAHPffJRvsefAC_09vlZvcrNjTClId8QI/export?gid=0&format=tsv',
+    '2017.8/tutorials/atacama-soils/sample_metadata':
+        'https://docs.google.com/spreadsheets/d/1xfDp25wDgnGAHPffJRvsefAC_09vlZvcrNjTClId8QI/edit?usp=sharing',
+    '2017.8/tutorials/fmt/sample_metadata.tsv':
+        'https://docs.google.com/spreadsheets/d/1hAAlr7pWzKBdKlzk_NN1vdIhsmepunkxSxSHl1Fcv4Y/export?gid=0&format=tsv',
+    '2017.8/tutorials/fmt/sample_metadata':
+        'https://docs.google.com/spreadsheets/d/1hAAlr7pWzKBdKlzk_NN1vdIhsmepunkxSxSHl1Fcv4Y/edit?usp=sharing',
+    '2017.8/tutorials/moving-pictures/sample_metadata.tsv':
+        'https://docs.google.com/spreadsheets/d/1h5tonfj9kIDPI2pwDInuEArn1_owGMWkr_1NlL1Evxk/export?gid=0&format=tsv',
+    '2017.8/tutorials/moving-pictures/sample_metadata':
+        'https://docs.google.com/spreadsheets/d/1h5tonfj9kIDPI2pwDInuEArn1_owGMWkr_1NlL1Evxk/edit?usp=sharing',
 }

--- a/urls.py
+++ b/urls.py
@@ -610,8 +610,8 @@ MAP = {
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/fmt/fmt-tutorial-demux-2-10p.qza',
     '2017.8/tutorials/fmt/fmt-tutorial-demux-2-1p.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/fmt/fmt-tutorial-demux-2-1p.qza',
-    '2017.8/tutorials/gneiss/map.txt':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/gneiss/map.txt',
+    '2017.8/tutorials/gneiss/sample-metadata.tsv':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/gneiss/sample-metadata.tsv',
     '2017.8/tutorials/gneiss/table.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2017.8/tutorials/gneiss/table.qza',
     '2017.8/tutorials/gneiss/taxa.qza':


### PR DESCRIPTION
Marking as "part 1 of N" because there are new tutorials still needing merge for 2017.8 that will require some new data links. The final step (step N) will be the usual VM link updates.