### PR TITLE
bug: typo in vm urls

### DIFF
--- a/urls/_2022.py
+++ b/urls/_2022.py
@@ -15,9 +15,9 @@ MAP_2022 = {
     'distro/core/qiime2-2022.2-py38-linux-conda.yml':
         'https://raw.githubusercontent.com/qiime2/environment-files/master/2022.2/release/qiime2-2022.2-py38-linux-conda.yml',
     'distro/core/2022.2':
-        'https://qiime2-data.s3.us-west-2.amazonaws.com/distro/core/qiime202111-1645722190.zip',
+        'https://qiime2-data.s3.us-west-2.amazonaws.com/distro/core/qiime20222-1645722190.zip',
     'distro/core/qiime20222-1645722190.zip':
-        'https://qiime2-data.s3.us-west-2.amazonaws.com/distro/core/qiime202111-1645722190.zip',
+        'https://qiime2-data.s3.us-west-2.amazonaws.com/distro/core/qiime20222-1645722190.zip',
 
     # 2022.4 DISTRO
     'distro/core/qiime2-2022.4-py38-osx-conda.yml':


### PR DESCRIPTION
The vbox urls have a lil copy-pasta in them, yum! 🍝 

Related, the [vbox](https://s3-us-west-2.amazonaws.com/qiime2-data/distro/core/virtualbox-images.txt) download doc didn't get updated, looks like that step is just missing from the playbook, so I'll add that now. If someone can tackle updating that download page that would be great!