### PR TITLE
new: adding usage-example URLs

### DIFF
--- a/urls/__init__.py
+++ b/urls/__init__.py
@@ -10,6 +10,7 @@
 
 from ._old import MAP_OLD
 from ._permanent import MAP_PERMANENT
+from ._usage import MAP_USAGE
 from ._2019 import MAP_2019
 from ._2020 import MAP_2020
 from ._2021 import MAP_2021
@@ -20,6 +21,8 @@ MAP = {
     **MAP_OLD,
 
     **MAP_PERMANENT,
+
+    **MAP_USAGE,
 
     **MAP_2019,
 

--- a/urls/_usage.py
+++ b/urls/_usage.py
@@ -1,0 +1,23 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2022, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+# flake8: noqa
+
+MAP_USAGE = {
+    # Atacama Soils
+    'usage-examples/atacama-soils/demux-full.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/usage-examples/atacama-soils/demux-full.qza',
+
+    # Moving Pictures
+    'usage-examples/moving-pictures/demux.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/usage-examples/moving-pictures/demux.qza',
+    'usage-examples/moving-pictures/rep-seqs-dada2.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/usage-examples/moving-pictures/rep-seqs-dada2.qza',
+    'usage-examples/moving-pictures/rep-seqs-deblur.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/usage-examples/moving-pictures/rep-seqs-deblur.qza',
+}


### PR DESCRIPTION
this PR adds a new set of URLs for our usage example data. these URLs are pulled from the docs-generated artifacts and uploaded to AWS under a separate folder so that we aren't dependent on a specific release (or a re-build of the docs) to access these files.