### PR TITLE
ex: adds bray-curtis and unweighted-unifrac pcoa result URLs

### DIFF
--- a/urls/_usage.py
+++ b/urls/_usage.py
@@ -28,6 +28,10 @@ MAP_USAGE = {
         'https://s3-us-west-2.amazonaws.com/qiime2-data/usage-examples/moving-pictures/core-metrics-results/faith_pd_vector.qza',
     'usage-examples/moving-pictures/core-metrics-results/jaccard_distance_matrix.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/usage-examples/moving-pictures/core-metrics-results/jaccard_distance_matrix.qza',
+    'usage-examples/moving-pictures/core-metrics-results/bray_curtis_pcoa_results.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/usage-examples/moving-pictures/core-metrics-results/bray_curtis_pcoa_results.qza',
+    'usage-examples/moving-pictures/core-metrics-results/unweighted_unifrac_pcoa_results.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/usage-examples/moving-pictures/core-metrics-results/unweighted_unifrac_pcoa_results.qza',
 
     # PD Mice
     'usage-examples/pd-mice/core-metrics-results/faith_pd_vector.qza':


### PR DESCRIPTION
this PR adds pcoa result URLs for bray curtis and unweighted unifrac for new usage examples