### PR TITLE
NEW: adds GG classifier links

### DIFF
--- a/urls/__init__.py
+++ b/urls/__init__.py
@@ -8,6 +8,7 @@
 
 # flake8: noqa
 
+from ._classifiers import MAP_CLASSIFIERS
 from ._old import MAP_OLD
 from ._permanent import MAP_PERMANENT
 from ._usage import MAP_USAGE
@@ -19,6 +20,8 @@ from ._2023 import MAP_2023
 
 
 MAP = {
+    **MAP_CLASSIFIERS,
+
     **MAP_OLD,
 
     **MAP_PERMANENT,

--- a/urls/_classifiers.py
+++ b/urls/_classifiers.py
@@ -19,5 +19,5 @@ MAP_CLASSIFIERS = {
     'classifiers/greengenes/gg_2022_10_backbone_full_length.nb.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/greengenes/gg_2022_10_backbone_full_length.nb.qza',
     'classifiers/greengenes/gg_2022_10_backbone.v4.nb.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/greengenes/gg_2022_10_backbone.v4.nb.qza',
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/greengenes/gg_2022_10_backbone.v4.nb.qza'
 }

--- a/urls/_classifiers.py
+++ b/urls/_classifiers.py
@@ -1,0 +1,23 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2023, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+# flake8: noqa
+
+MAP_CLASSIFIERS = {
+    # Greengenes
+    'classifiers/greengenes/gg_12_10_otus.tar.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/greengenes/gg_12_10_otus.tar.gz',
+    'classifiers/greengenes/gg_13_5_otus.tar.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/greengenes/gg_13_5_otus.tar.gz',
+    'classifiers/greengenes/gg_13_8_otus.tar.gz':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/greengenes/gg_13_8_otus.tar.gz',
+    'classifiers/greengenes/gg_2022_10_backbone_full_length.nb.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/greengenes/gg_2022_10_backbone_full_length.nb.qza',
+    'classifiers/greengenes/gg_2022_10_backbone.v4.nb.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/greengenes/gg_2022_10_backbone.v4.nb.qza',
+}


### PR DESCRIPTION
This PR adds links for the new GG classifiers that we are now hosting on AWS, since the hosting location for these files was not over https.