### PR TITLE
MAINT: updating URLs for 2024.5 with retrained classifiers

### DIFF
--- a/urls/_2024.py
+++ b/urls/_2024.py
@@ -270,22 +270,14 @@ MAP_2024 = {
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/2022.10.backbone.v4.nb.sklearn-1.4.2.qza',
     '2024.5/common/gtdb_classifier_r220.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/gtdb_classifier_r220.qza',
+    '2024.5/common/gtdb_weighted_classifier_r220.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/gtdb_weighted_classifier_r220.qza',
     '2024.5/common/gg-13-8-99-515-806-nb-classifier.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/gg-13-8-99-515-806-nb-classifier.qza',
-    '2024.5/common/gg-13-8-99-515-806-nb-weighted-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/gg-13-8-99-515-806-nb-weighted-classifier.qza',
-    '2024.5/common/gg-13-8-99-nb-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/gg-13-8-99-nb-classifier.qza',
-    '2024.5/common/gg-13-8-99-nb-weighted-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/gg-13-8-99-nb-weighted-classifier.qza',
     '2024.5/common/sepp-refs-gg-13-8.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/sepp-refs-gg-13-8.qza',
     '2024.5/common/sepp-refs-silva-128.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/sepp-refs-silva-128.qza',
-    '2024.5/common/silva-138-99-515-806-nb-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/silva-138-99-515-806-nb-classifier.qza',
-    '2024.5/common/silva-138-99-515-806-nb-weighted-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/silva-138-99-515-806-nb-weighted-classifier.qza',
     '2024.5/common/silva-138-99-nb-classifier.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/silva-138-99-nb-classifier.qza',
     '2024.5/common/silva-138-99-nb-weighted-classifier.qza':
@@ -508,22 +500,14 @@ MAP_2024 = {
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/2022.10.backbone.v4.nb.sklearn-1.4.2.qza',
     '2024.10/common/gtdb_classifier_r220.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/gtdb_classifier_r220.qza',
+    '2024.10/common/gtdb_weighted_classifier_r220.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/gtdb_weighted_classifier_r220.qza',
     '2024.10/common/gg-13-8-99-515-806-nb-classifier.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/gg-13-8-99-515-806-nb-classifier.qza',
-    '2024.10/common/gg-13-8-99-515-806-nb-weighted-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/gg-13-8-99-515-806-nb-weighted-classifier.qza',
-    '2024.10/common/gg-13-8-99-nb-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/gg-13-8-99-nb-classifier.qza',
-    '2024.10/common/gg-13-8-99-nb-weighted-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/gg-13-8-99-nb-weighted-classifier.qza',
     '2024.10/common/sepp-refs-gg-13-8.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/sepp-refs-gg-13-8.qza',
     '2024.10/common/sepp-refs-silva-128.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/sepp-refs-silva-128.qza',
-    '2024.10/common/silva-138-99-515-806-nb-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/silva-138-99-515-806-nb-classifier.qza',
-    '2024.10/common/silva-138-99-515-806-nb-weighted-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/silva-138-99-515-806-nb-weighted-classifier.qza',
     '2024.10/common/silva-138-99-nb-classifier.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/silva-138-99-nb-classifier.qza',
     '2024.10/common/silva-138-99-nb-weighted-classifier.qza':


### PR DESCRIPTION
updating the classifier URLs listed under 2024.5 and 2024.10 to only include the classifiers that were retrained with new sklearn. gtdb and silva weighted full length classifiers were added to AWS (gtdb is the only visible addition here since silva has existed under previous release versions), and old gg/silva (region specific) have been removed.

note that these still exist on AWS under prior release versions (and those URLs still exist in data302) - i'm just removing them from this release forward since they haven't been retrained with the new sklearn version we're using.