### PR TITLE
MAINT: removes old classifier URLs that are no longer being used

### DIFF
--- a/urls/_2024.py
+++ b/urls/_2024.py
@@ -286,14 +286,6 @@ MAP_2024 = {
     # these are only used in the deprecated resources page
     '2024.5/common/sepp-refs-silva-128.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/sepp-refs-silva-128.qza',
-    '2024.5/common/silva-138-99-seqs-515-806.qza':
-        'https://qiime2-data.s3-us-west-2.amazonaws.com/2024.5/common/silva-138-99-seqs-515-806.qza',
-    '2024.5/common/silva-138-99-seqs.qza':
-        'https://qiime2-data.s3-us-west-2.amazonaws.com/2024.5/common/silva-138-99-seqs.qza',
-    '2024.5/common/silva-138-99-tax-515-806.qza':
-        'https://qiime2-data.s3-us-west-2.amazonaws.com/2024.5/common/silva-138-99-tax-515-806.qza',
-    '2024.5/common/silva-138-99-tax.qza':
-        'https://qiime2-data.s3-us-west-2.amazonaws.com/2024.5/common/silva-138-99-tax.qza',
 
     # these are used in tutorials
     '2024.5/common/gg-13-8-99-515-806-nb-classifier.qza':
@@ -509,14 +501,6 @@ MAP_2024 = {
     # these are only used in the deprecated resources page
     '2024.10/common/sepp-refs-silva-128.qza':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/sepp-refs-silva-128.qza',
-    '2024.10/common/silva-138-99-seqs-515-806.qza':
-        'https://qiime2-data.s3-us-west-2.amazonaws.com/2024.10/common/silva-138-99-seqs-515-806.qza',
-    '2024.10/common/silva-138-99-seqs.qza':
-        'https://qiime2-data.s3-us-west-2.amazonaws.com/2024.10/common/silva-138-99-seqs.qza',
-    '2024.10/common/silva-138-99-tax-515-806.qza':
-        'https://qiime2-data.s3-us-west-2.amazonaws.com/2024.10/common/silva-138-99-tax-515-806.qza',
-    '2024.10/common/silva-138-99-tax.qza':
-        'https://qiime2-data.s3-us-west-2.amazonaws.com/2024.10/common/silva-138-99-tax.qza',
 
     # these are used in tutorials
     '2024.10/common/gg-13-8-99-515-806-nb-classifier.qza':

--- a/urls/_2024.py
+++ b/urls/_2024.py
@@ -283,16 +283,6 @@ MAP_2024 = {
 
     # 2024.5
 
-    # these are only used in the deprecated resources page
-    '2024.5/common/sepp-refs-silva-128.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/sepp-refs-silva-128.qza',
-
-    # these are used in tutorials
-    '2024.5/common/gg-13-8-99-515-806-nb-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/gg-13-8-99-515-806-nb-classifier.qza',
-    '2024.5/common/sepp-refs-gg-13-8.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/sepp-refs-gg-13-8.qza',
-
     '2024.5/tutorials/atacama-soils/10p/barcodes.fastq.gz':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/tutorials/atacama-soils/10p/barcodes.fastq.gz',
     '2024.5/tutorials/atacama-soils/10p/forward.fastq.gz':
@@ -497,16 +487,6 @@ MAP_2024 = {
         'https://raw.githubusercontent.com/qiime2/distributions/dev/2024.10/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml',
 
     # 2024.10
-
-    # these are only used in the deprecated resources page
-    '2024.10/common/sepp-refs-silva-128.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/sepp-refs-silva-128.qza',
-
-    # these are used in tutorials
-    '2024.10/common/gg-13-8-99-515-806-nb-classifier.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/gg-13-8-99-515-806-nb-classifier.qza',
-    '2024.10/common/sepp-refs-gg-13-8.qza':
-        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/common/sepp-refs-gg-13-8.qza',
 
     '2024.10/tutorials/atacama-soils/10p/barcodes.fastq.gz':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.10/tutorials/atacama-soils/10p/barcodes.fastq.gz',

--- a/urls/_2024.py
+++ b/urls/_2024.py
@@ -283,6 +283,12 @@ MAP_2024 = {
 
     # 2024.5
 
+    # these are used in tutorials
+    '2024.5/common/gg-13-8-99-515-806-nb-classifier.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/gg-13-8-99-515-806-nb-classifier.qza',
+    '2024.5/common/sepp-refs-gg-13-8.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/common/sepp-refs-gg-13-8.qza',
+
     '2024.5/tutorials/atacama-soils/10p/barcodes.fastq.gz':
         'https://s3-us-west-2.amazonaws.com/qiime2-data/2024.5/tutorials/atacama-soils/10p/barcodes.fastq.gz',
     '2024.5/tutorials/atacama-soils/10p/forward.fastq.gz':

--- a/urls/_classifiers.py
+++ b/urls/_classifiers.py
@@ -9,6 +9,14 @@
 # flake8: noqa
 
 MAP_CLASSIFIERS = {
+    # sklearn 0.21.2
+
+    # SEPP reference databases
+    'classifiers/sklearn-0.21.2/sepp-ref-dbs/sepp-refs-gg-13-8.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/sklearn-0.21.2/sepp-ref-dbs/sepp-refs-gg-13-8.qza',
+    'classifiers/sklearn-0.21.2/sepp-ref-dbs/sepp-refs-silva-128.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/sklearn-0.21.2/sepp-ref-dbs/sepp-refs-silva-128.qza',
+
     # sklearn 0.24.1
 
     # Greengenes
@@ -24,6 +32,10 @@ MAP_CLASSIFIERS = {
         'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/greengenes/gg_2022_10_backbone.v4.nb.qza',
 
     # sklearn 1.4.2
+
+    # Greengenes
+    'classifiers/sklearn-1.4.2/greengenes/gg-13-8-99-515-806-nb-classifier.qza':
+        'https://s3-us-west-2.amazonaws.com/qiime2-data/classifiers/sklearn-1.4.2/greengenes/gg-13-8-99-515-806-nb-classifier.qza',
 
     # Greengenes 2
     'classifiers/sklearn-1.4.2/greengenes2/2022.10.backbone.full-length.nb.sklearn-1.4.2.qza':


### PR DESCRIPTION
removing these for our current release onward because we're no longer using them. paired with https://github.com/qiime2/docs/pull/587